### PR TITLE
[Privacy] Ensure episodic memory vectors are deleted when clearing user data

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1048,6 +1048,14 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
 
+                # Also delete episodic memory vectors for privacy compliance
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and getattr(vector_manager, "store", None):
+                        await vector_manager.store.delete_vectors_by_user(user_id)
+                        self.logger.info(f"Deleted episodic vectors for user {user_id}")
+                except Exception as vec_err:
+                    self.logger.warning(f"Failed to delete episodic vectors for {user_id}: {vec_err}")
 
                 return self._translate(
                     guild_id,


### PR DESCRIPTION
1. **What was found**: Episodic memory vectors were left intact when a user triggered personal data deletion via `_clear_user_data`.
2. **Where it is**: `cogs/userdata.py` inside the `_clear_user_data` method.
3. **Why it matters**: Keeping conversation fragments and vector embeddings after a user specifically requests their data be cleared is a significant privacy violation.
4. **What was done**: Added explicit logic to check for the bot's `vector_manager` and call `delete_vectors_by_user(user_id)` to scrub the vector database synchronously alongside the procedural data deletion.

---
*PR created automatically by Jules for task [7284154087020932842](https://jules.google.com/task/7284154087020932842) started by @zi-yue-1129*