### PR TITLE
[Privacy] Fix UserDataCog._clear_user_data not deleting episodic memory vectors

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1034,6 +1034,18 @@ class UserDataCog(commands.Cog):
 
             success = await self.user_manager.delete_user_data(user_id)
             if success:
+                # Delete episodic memory vectors to comply with privacy deletion
+                from addons.settings import memory_config
+                if getattr(memory_config, "enabled", True):
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store"):
+                        try:
+                            await vector_manager.store.delete_vectors_by_user(user_id)
+                        except Exception as e:
+                            self.logger.error(f"Failed to delete episodic vectors for user {user_id}: {e}")
+                    else:
+                        self.logger.error("Critical: vector_manager or store is missing while memory is enabled. Cannot delete episodic memory vectors.")
+
                 # Invalidate ProceduralMemoryProvider cache
                 try:
                     orchestrator = getattr(self.bot, "orchestrator", None)


### PR DESCRIPTION
What was found:
When a user completely clears their data via `UserDataCog._clear_user_data`, the current implementation successfully deletes their procedural data (using `user_manager.delete_user_data`) and invalidates the procedural cache, but it completely fails to delete their episodic memory vectors stored in the vector store (e.g., Qdrant). This violates the core privacy contract for data deletion.

Where it is:
`cogs/userdata.py` inside the `_clear_user_data` method.

Why it matters:
When users request to clear their data, they expect all their data (including their historical conversational memory in the episodic vector store) to be purged. Retaining semantic episodic data while clearing procedural data is a major privacy vulnerability, particularly for compliance with GDPR or general user trust.

What was done:
I modified `UserDataCog._clear_user_data` in `cogs/userdata.py` to add explicit logic to delete a user's episodic vectors. It attempts to safely retrieve the vector store via `self.bot.vector_manager` and calls `await vector_manager.store.delete_vectors_by_user(user_id)`. If the vector manager is missing while memory is supposedly enabled, or if the API call errors out, it now gracefully logs a descriptive error to avoid crashing the rest of the teardown flow.

---
*PR created automatically by Jules for task [2905721712184457891](https://jules.google.com/task/2905721712184457891) started by @zi-yue-1129*