### PR TITLE
[UX] Fix hanging 'Thinking...' states in slash commands

### DIFF
--- a/cogs/remind.py
+++ b/cogs/remind.py
@@ -50,7 +50,7 @@ class ReminderCog(commands.Cog):
 
             # 如果是來自斜線命令，先發送一個 "已收到" 的臨時回覆
             if interaction:
-                await interaction.followup.send(self.lang_manager.translate(guild_id, "commands", "remind", "responses", "received"), ephemeral=True)
+                await interaction.edit_original_response(content=self.lang_manager.translate(guild_id, "commands", "remind", "responses", "received"))
 
             reminder_time = self.parse_time(time_str, guild_id)
             if reminder_time is None:
@@ -134,7 +134,7 @@ class ReminderCog(commands.Cog):
         user="The user to remind (optional, defaults to yourself)"
     )
     async def remind(self, interaction: discord.Interaction, time: str, message: str, user: discord.User = None):
-        await interaction.response.defer(ephemeral=True)
+        await interaction.response.defer(ephemeral=True, thinking=True)
         
         guild_id = str(interaction.guild_id)
         target_user = user or interaction.user

--- a/cogs/system_prompt/commands.py
+++ b/cogs/system_prompt/commands.py
@@ -210,7 +210,7 @@ class SystemPromptCommands(commands.Cog):
             scope: Choice of "channel" or "server".
             description: Natural language description of the desired personality change.
         """
-        await interaction.response.defer(ephemeral=True)
+        await interaction.response.defer(ephemeral=True, thinking=True)
 
         guild_id = str(interaction.guild.id) if interaction.guild else "0"
         channel_id = str(interaction.channel.id) if interaction.channel else "0"
@@ -222,16 +222,13 @@ class SystemPromptCommands(commands.Cog):
             from .permissions import PermissionValidator
             validator = PermissionValidator(self.bot)
             if not validator.can_modify_server_prompt(interaction.user, interaction.guild):
-                await interaction.followup.send(
-                    "❌ You need administrator permissions to modify the server-level personality.",
-                    ephemeral=True,
-                )
+                await interaction.edit_original_response(content="❌ You need administrator permissions to modify the server-level personality.")
                 return
 
         # Get current effective system prompt to merge with
         sp_cog = self.bot.get_cog("SystemPromptManagerCog")
         if sp_cog is None:
-            await interaction.followup.send("❌ System prompt module is not loaded.", ephemeral=True)
+            await interaction.edit_original_response(content="❌ System prompt module is not loaded.")
             return
 
         manager = sp_cog.get_system_prompt_manager()
@@ -247,7 +244,7 @@ class SystemPromptCommands(commands.Cog):
             model_priority = model_manager.get_model_priority_list("message_model")
             model_instance = create_model_instance(model_priority[0], max_retries=1)
         except Exception as exc:
-            await interaction.followup.send(f"❌ Failed to load language model: {exc}", ephemeral=True)
+            await interaction.edit_original_response(content=f"❌ Failed to load language model: {exc}")
             return
 
         merge_prompt = (
@@ -263,7 +260,7 @@ class SystemPromptCommands(commands.Cog):
             response = await model_instance.ainvoke([HumanMessage(content=merge_prompt)])
             merged_prompt = response.content if hasattr(response, "content") else str(response)
         except Exception as exc:
-            await interaction.followup.send(f"❌ Failed to generate merged prompt: {exc}", ephemeral=True)
+            await interaction.edit_original_response(content=f"❌ Failed to generate merged prompt: {exc}")
             return
 
         # Write using shared helper
@@ -278,12 +275,9 @@ class SystemPromptCommands(commands.Cog):
         )
 
         if result.startswith("Error"):
-            await interaction.followup.send(f"❌ {result}", ephemeral=True)
+            await interaction.edit_original_response(content=f"❌ {result}")
         else:
-            await interaction.followup.send(
-                f"✅ {result}\n\nApplied change: *{description}*",
-                ephemeral=True,
-            )
+            await interaction.edit_original_response(content=f"✅ {result}\n\nApplied change: *{description}*")
 
 
 


### PR DESCRIPTION
1. **What was found**: Found instances in `cogs/remind.py` and `cogs/system_prompt/commands.py` where `interaction.followup.send()` was used as the first response immediately after `interaction.response.defer(ephemeral=True)`.
2. **Where it is**: `cogs/remind.py` (line 137, 53) and `cogs/system_prompt/commands.py` (line 213, and various responses inside `set_personality`).
3. **Why it matters**: In `discord.py`, using `followup.send()` instead of `edit_original_response()` immediately after deferring leaves the original "Bot is thinking..." message hanging permanently in the Discord UI, creating a confusing and unpleasant UX for users.
4. **What was done**: Modified the initial defer call to include `thinking=True` and updated the subsequent `followup.send()` calls to use `edit_original_response(content=...)`, correctly replacing the "thinking" message with the final response.

---
*PR created automatically by Jules for task [3356979322028058051](https://jules.google.com/task/3356979322028058051) started by @zi-yue-1129*