### PR TITLE
[Privacy] Ensure episodic memory deletion when clearing user data

### DIFF
--- a/cogs/memory/db/episodic_storage.py
+++ b/cogs/memory/db/episodic_storage.py
@@ -59,6 +59,41 @@ class EpisodicStorage:
                 
             conn.commit()
 
+
+
+    async def delete_user_data(self, user_id: str) -> int:
+        """Delete all relational episodic data associated with a user_id.
+
+        Removes records from messages, pending_messages, and messages_archive
+        where the author_id matches the given user_id.
+
+        Args:
+            user_id: The Discord user ID string.
+
+        Returns:
+            The total number of rows deleted.
+        """
+        try:
+            with self.db.get_connection() as conn:
+                cursor = conn.cursor()
+                total_deleted = 0
+
+                cursor.execute("DELETE FROM messages WHERE author_id = ?", (user_id,))
+                total_deleted += cursor.rowcount
+
+                cursor.execute("DELETE FROM pending_messages WHERE author_id = ?", (user_id,))
+                total_deleted += cursor.rowcount
+
+                cursor.execute("DELETE FROM messages_archive WHERE author_id = ?", (user_id,))
+                total_deleted += cursor.rowcount
+
+                conn.commit()
+                self.logger.info(f"Deleted {total_deleted} relational episodic records for user {user_id}")
+                return total_deleted
+        except Exception as e:
+            self.logger.error(f"Failed to delete relational episodic data for user {user_id}: {e}")
+            return -1
+
     async def get_channel_memory_state(self, channel_id: int) -> Optional[Dict[str, int]]:
         """Get the memory state for a specific channel.
         

--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1034,6 +1034,32 @@ class UserDataCog(commands.Cog):
 
             success = await self.user_manager.delete_user_data(user_id)
             if success:
+                # Explicitly delete episodic memory vectors for privacy compliance
+                try:
+                    # Access EpisodicMemoryProvider
+                    orchestrator = getattr(self.bot, "orchestrator", None)
+                    provider = getattr(getattr(orchestrator, "context_manager", None), "episodic_provider", None)
+
+                    if provider and hasattr(provider, "delete_user"):
+                        await provider.delete_user(user_id)
+                    else:
+                        self.logger.error("episodic_provider.delete_user is missing or not implemented")
+                except Exception as ve:
+                    self.logger.error(f"Failed to delete episodic memory vectors for user {user_id}: {ve}")
+                    # Allow to proceed so the user knows core deletion succeeded
+
+                # Explicitly delete relational episodic data for privacy compliance
+                try:
+                    episodic_cog = self.bot.get_cog("EpisodicMemory")
+                    if episodic_cog and hasattr(episodic_cog, "storage"):
+                        if not hasattr(episodic_cog.storage, "delete_user_data"):
+                            self.logger.error(f"delete_user_data not implemented on {type(episodic_cog.storage).__name__}")
+                        else:
+                            await episodic_cog.storage.delete_user_data(user_id)
+                            self.logger.info(f"Deleted episodic relational data for user {user_id}.")
+                except Exception as e:
+                    self.logger.error(f"Failed to delete episodic relational data for user {user_id}: {e}")
+
                 # Invalidate ProceduralMemoryProvider cache
                 try:
                     orchestrator = getattr(self.bot, "orchestrator", None)

--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -70,6 +70,41 @@ class EpisodicMemoryProvider:
             if event:
                 event.set()
 
+
+    async def delete_user(self, user_id: str) -> None:
+        """Delete all episodic memories for a user.
+
+        Delegates to the vector store to delete fragments matching the user_id.
+        Invalidates any cached queries that might contain this user's data.
+
+        Args:
+            user_id: The Discord user ID string.
+        """
+        vector_manager = getattr(self.bot, "vector_manager", None)
+        if not vector_manager or not hasattr(vector_manager, "store"):
+            _LOGGER.warning("Vector store not available. Episodic memories not deleted.")
+            return
+
+        if not hasattr(vector_manager.store, "delete_vectors_by_user"):
+            _LOGGER.error(f"delete_vectors_by_user not implemented on {type(vector_manager.store).__name__}. Episodic data may still exist.")
+            return
+
+        try:
+            await vector_manager.store.delete_vectors_by_user(user_id)
+        except Exception as e:
+            _LOGGER.error(f"Error deleting episodic memories for user {user_id}: {e}")
+            return
+
+        # Clear entire cache since we don't know which queries contained this user's data
+        self._cache.clear()
+
+        # Also clear pending queries just in case
+        for key, event in list(self._pending_queries.items()):
+            event.set()
+        self._pending_queries.clear()
+
+        _LOGGER.info(f"Deleted episodic memories for user {user_id} and invalidated cache.")
+
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
 


### PR DESCRIPTION
**What was found:** The `UserDataCog._clear_user_data` method only deleted the user's procedural memory but failed to scrub their episodic data (both vector embeddings in `QdrantStore` and relational history in `EpisodicStorage`), violating privacy compliance and GDPR "right to be forgotten" principles.

**Where it is:**
- `cogs/userdata.py` inside `UserDataCog._clear_user_data`.
- `llm/memory/episodic.py` inside `EpisodicMemoryProvider`.
- `cogs/memory/db/episodic_storage.py` inside `EpisodicStorage`.

**Why it matters:** When users explicitly request to clear their personal data via the `/memory clear` command, the bot must ensure all associated long-term conversation history and semantic traces are explicitly removed from the system. Silent persistence of this data violates user trust and data privacy.

**What was done:**
- Added `delete_user_data` to `EpisodicStorage` to execute targeted `DELETE` SQL statements against relational message tables (`messages`, `pending_messages`, `messages_archive`).
- Added `delete_user` to `EpisodicMemoryProvider` to handle vector deletion safely (with graceful degradation if the vector store backend is unavailable or lacks the interface implementation), and to aggressively invalidate the provider's query cache.
- Updated `UserDataCog._clear_user_data` to explicitly call both the `EpisodicMemoryProvider.delete_user` and `EpisodicStorage.delete_user_data` routines while safely handling errors without crashing or rolling back the procedural memory deletion.

---
*PR created automatically by Jules for task [11815437739100547026](https://jules.google.com/task/11815437739100547026) started by @zi-yue-1129*