### PR TITLE
[Perf] Add LRU cache for short-term memory attachments

### DIFF
--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -1,5 +1,6 @@
 from typing import List, Any
 import re
+from collections import OrderedDict
 
 import discord
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
@@ -14,17 +15,20 @@ class ShortTermMemoryProvider:
     each Discord message to a LangChain HumanMessage or AIMessage.
     """
 
-    def __init__(self, bot: Any, limit: int = 10):
+    def __init__(self, bot: Any, limit: int = 10, max_cache_size: int = 50):
         """
         Initialize the provider.
 
         Args:
             limit: maximum number of recent messages to fetch from channel.
+            max_cache_size: maximum number of processed attachments to cache.
         """
         if not isinstance(limit, int) or limit <= 0:
             raise ValueError("limit must be a positive integer")
         self.limit = limit
         self.bot = bot
+        self.max_cache_size = max_cache_size
+        self._attachment_cache: OrderedDict = OrderedDict()
 
     async def get(self, message: discord.Message) -> List[BaseMessage]:
         """
@@ -44,21 +48,33 @@ class ShortTermMemoryProvider:
 
             # Pre-fetch all attachments concurrently
             attachment_tasks = []
-            task_mapping = []  # To map task index back to msg.id
+            task_mapping = []  # To map task index back to (msg.id, att.id)
+            attachment_results_by_msg = {}
+
             if _att_cfg.enabled:
                 for msg in history:
                     if msg.attachments:
                         for att in msg.attachments:
-                            attachment_tasks.append(process_attachment(att))
-                            task_mapping.append(msg.id)
+                            if att.id in self._attachment_cache:
+                                # Cache hit: update LRU order and use result
+                                cached_result = self._attachment_cache.pop(att.id)
+                                self._attachment_cache[att.id] = cached_result
+                                attachment_results_by_msg.setdefault(msg.id, []).extend(cached_result)
+                            else:
+                                attachment_tasks.append(process_attachment(att))
+                                task_mapping.append((msg.id, att.id))
 
-            attachment_results_by_msg = {}
             if attachment_tasks:
                 import asyncio
                 results = await asyncio.gather(*attachment_tasks, return_exceptions=True)
-                for msg_id, res in zip(task_mapping, results):
+                for (msg_id, att_id), res in zip(task_mapping, results):
                     if not isinstance(res, Exception) and isinstance(res, list):
                         attachment_results_by_msg.setdefault(msg_id, []).extend(res)
+                        # Cache the successful result
+                        self._attachment_cache[att_id] = res
+                        # Prune cache if it exceeds max size
+                        if len(self._attachment_cache) > self.max_cache_size:
+                            self._attachment_cache.popitem(last=False)
                     else:
                         # Fallback or log error could go here if process_attachment didn't handle it
                         pass


### PR DESCRIPTION
**What was found:** 
Short-term memory fetches the last N (default 10) messages from a channel and processes any attachments within them. Because this happens on *every* new message processed by the orchestrator, and the sliding window overlaps, recent attachments were being redundantly downloaded and re-processed over and over.

**Where it is:**
`llm/memory/short_term.py` (lines 45-80, inside `ShortTermMemoryProvider.get()`).

**Why it matters:**
Processing an attachment involves an HTTP GET request (sometimes 15s timeout) and CPU-heavy operations like resizing images (`PIL.Image`) or base64 encoding. Redoing this for the same image 10 times consecutively significantly increases bot latency and wastes network bandwidth/CPU.

**What was done:**
Added a bounded LRU cache (using `collections.OrderedDict`) to `ShortTermMemoryProvider`. When iterating through messages, the provider now checks if the attachment ID already exists in `self._attachment_cache`. If so, it uses the cached `content_parts` immediately. If not, it falls back to the original `asyncio.gather` concurrent fetch and stores the result back in the cache. The cache has a default size limit (`max_cache_size=50`) to prevent unbound memory growth.

---
*PR created automatically by Jules for task [1047679124261347033](https://jules.google.com/task/1047679124261347033) started by @zi-yue-1129*