### PR TITLE
[UX] Add thinking state to deferred commands

### DIFF
--- a/cogs/botinfo.py
+++ b/cogs/botinfo.py
@@ -63,7 +63,7 @@ class BotInfo(commands.Cog):
                 self.botinfo.description = localized_desc
 
         try:
-            await interaction.response.defer()
+            await interaction.response.defer(thinking=True)
 
             bot = interaction.client
             guild_id = str(interaction.guild_id) if interaction.guild_id else "0"
@@ -198,7 +198,7 @@ class BotInfo(commands.Cog):
                 icon_url=avatar_url
             )
 
-            await interaction.followup.send(embed=main_embed)
+            await interaction.edit_original_response(embed=main_embed)
         except Exception as e:
             await func.report_error(e, "getting bot info")
 

--- a/cogs/gif_tools.py
+++ b/cogs/gif_tools.py
@@ -113,18 +113,18 @@ class GifTools(commands.Cog):
         if not self.lang_manager:
             self.lang_manager = LanguageManager.get_instance(self.bot)
             
-        await interaction.response.defer()
+        await interaction.response.defer(thinking=True)
         guild_id = str(interaction.guild_id)
         
         gifs = await self.search_gif(query)
         if gifs:
             gif_url = random.choice(gifs)
-            await interaction.followup.send(gif_url)
+            await interaction.edit_original_response(content=gif_url)
         else:
             not_found_message = self.lang_manager.translate(
                 guild_id, "commands", "search_gif", "responses", "not_found"
             ) if self.lang_manager else "找不到相關的 GIF。"
-            await interaction.followup.send(not_found_message)
+            await interaction.edit_original_response(content=not_found_message)
 
     async def get_gif_url(self, query: str, guild_id: str = "0") -> str:
         """取得隨機一個符合搜尋條件的 GIF URL。

--- a/cogs/update_manager.py
+++ b/cogs/update_manager.py
@@ -82,7 +82,7 @@ class UpdateManagerCog(commands.Cog):
             await interaction.response.send_message(not_initialized_msg, ephemeral=True)
             return
         
-        await interaction.response.defer()
+        await interaction.response.defer(thinking=True)
         
         try:
             result = await self.update_manager.check_for_updates()
@@ -129,9 +129,9 @@ class UpdateManagerCog(commands.Cog):
                 # 只有擁有者才顯示更新按鈕
                 if self.permission_checker.check_update_permission(interaction.user.id):
                     view = UpdateActionView(self.update_manager, guild_id, self._get_translation)
-                    await interaction.followup.send(embed=embed, view=view)
+                    await interaction.edit_original_response(embed=embed, view=view)
                 else:
-                    await interaction.followup.send(embed=embed)
+                    await interaction.edit_original_response(embed=embed)
             else:
                 status_label = self._get_translation(guild_id, "commands", "update_manager", "commands", "check_update", "up_to_date", "status")
                 status_field_name = self._get_translation(guild_id, "commands", "update_manager", "fields", "status")
@@ -140,7 +140,7 @@ class UpdateManagerCog(commands.Cog):
                     value=status_label,
                     inline=False
                 )
-                await interaction.followup.send(embed=embed)
+                await interaction.edit_original_response(embed=embed)
                 
         except Exception as e:
             self.logger.error(f"檢查更新時發生錯誤: {e}")
@@ -152,7 +152,7 @@ class UpdateManagerCog(commands.Cog):
                 description=error_desc,
                 color=discord.Color.red()
             )
-            await interaction.followup.send(embed=embed)
+            await interaction.edit_original_response(embed=embed)
     
     @app_commands.command(name="update_now", description="立即執行更新（僅限擁有者）")
     async def update_now(self, interaction: discord.Interaction, force: bool = False):
@@ -174,7 +174,7 @@ class UpdateManagerCog(commands.Cog):
             await interaction.response.send_message(not_initialized_msg, ephemeral=True)
             return
         
-        await interaction.response.defer()
+        await interaction.response.defer(thinking=True)
         
         try:
             # 檢查更新狀態
@@ -187,7 +187,7 @@ class UpdateManagerCog(commands.Cog):
                     description=busy_desc,
                     color=discord.Color.orange()
                 )
-                await interaction.followup.send(embed=embed)
+                await interaction.edit_original_response(embed=embed)
                 return
             
             # 檢查是否有可用更新
@@ -201,7 +201,7 @@ class UpdateManagerCog(commands.Cog):
                         description=no_update_desc,
                         color=discord.Color.blue()
                     )
-                    await interaction.followup.send(embed=embed)
+                    await interaction.edit_original_response(embed=embed)
                     return
                 
                 # 創建確認視圖
@@ -235,7 +235,7 @@ class UpdateManagerCog(commands.Cog):
                 warning_field_name = self._get_translation(guild_id, "commands", "update_manager", "fields", "warning")
                 embed.add_field(name=warning_field_name, value=force_warning, inline=False)
             
-            await interaction.followup.send(embed=embed, view=view)
+            await interaction.edit_original_response(embed=embed, view=view)
             
         except Exception as e:
             self.logger.error(f"準備更新時發生錯誤: {e}")
@@ -247,7 +247,7 @@ class UpdateManagerCog(commands.Cog):
                 description=error_desc,
                 color=discord.Color.red()
             )
-            await interaction.followup.send(embed=embed)
+            await interaction.edit_original_response(embed=embed)
     
     @app_commands.command(name="update_status", description="查看更新系統狀態")
     async def update_status(self, interaction: discord.Interaction):


### PR DESCRIPTION
1. **What was found:** Several commands (`botinfo`, `search_gif`, and multiple commands in `update_manager`) deferred their responses but did not show a "Thinking..." indicator. Additionally, they responded using `followup.send` which can leave the "Thinking..." indicator hanging while appending a new message.
2. **Where it is:** `cogs/botinfo.py`, `cogs/gif_tools.py`, and `cogs/update_manager.py`.
3. **Why it matters:** Providing visual feedback that a command is processing is a fundamental part of good UX. Leaving hanging "Thinking..." messages degrades the user experience by cluttering the channel.
4. **What was done:** Updated the relevant `interaction.response.defer()` calls to include `thinking=True` (or preserved it where omitted, for consistency as slash commands default to thinking state), and consistently changed `interaction.followup.send` (and `followup.edit_message` for initial views) to `interaction.edit_original_response` so that the original interaction message correctly resolves the thinking state.

---
*PR created automatically by Jules for task [8486142406260605302](https://jules.google.com/task/8486142406260605302) started by @zi-yue-1129*