### PR TITLE
[Perf] Add LRU cache to ShortTermMemoryProvider attachment processing

### DIFF
--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -1,4 +1,5 @@
 from typing import List, Any
+from collections import OrderedDict
 import re
 
 import discord
@@ -25,6 +26,8 @@ class ShortTermMemoryProvider:
             raise ValueError("limit must be a positive integer")
         self.limit = limit
         self.bot = bot
+        self._attachment_cache = OrderedDict()
+        self._max_cache_size = 50
 
     async def get(self, message: discord.Message) -> List[BaseMessage]:
         """
@@ -44,21 +47,29 @@ class ShortTermMemoryProvider:
 
             # Pre-fetch all attachments concurrently
             attachment_tasks = []
-            task_mapping = []  # To map task index back to msg.id
+            task_mapping = []
+            attachment_results_by_msg = {}  # To map task index back to msg.id
             if _att_cfg.enabled:
                 for msg in history:
                     if msg.attachments:
                         for att in msg.attachments:
-                            attachment_tasks.append(process_attachment(att))
-                            task_mapping.append(msg.id)
+                            if att.id in self._attachment_cache:
+                                attachment_results_by_msg.setdefault(msg.id, []).extend(self._attachment_cache[att.id])
+                            else:
+                                attachment_tasks.append(process_attachment(att))
+                                task_mapping.append((msg.id, att.id))
 
-            attachment_results_by_msg = {}
             if attachment_tasks:
                 import asyncio
                 results = await asyncio.gather(*attachment_tasks, return_exceptions=True)
-                for msg_id, res in zip(task_mapping, results):
+                for (msg_id, att_id), res in zip(task_mapping, results):
                     if not isinstance(res, Exception) and isinstance(res, list):
                         attachment_results_by_msg.setdefault(msg_id, []).extend(res)
+
+                        # Cache the result
+                        self._attachment_cache[att_id] = res
+                        if len(self._attachment_cache) > self._max_cache_size:
+                            self._attachment_cache.popitem(last=False)
                     else:
                         # Fallback or log error could go here if process_attachment didn't handle it
                         pass


### PR DESCRIPTION
### What was found
The `ShortTermMemoryProvider` processes recent message history (usually the last 10 messages) on every interaction. If an older message contains an attachment (like an image or PDF), it gets re-downloaded and re-decoded into an LLM content part on *every* subsequent turn of the conversation until it falls out of the sliding window.

### Where it is
File: `llm/memory/short_term.py`
Method: `ShortTermMemoryProvider.get`

### Why it matters
Fetching and processing media (via PIL, pdf2image, decord) is highly I/O bound and computationally expensive. Repeating this redundant work for the same attachment significantly increases response latency and consumes unnecessary network bandwidth. 

### What was done
I injected a simple, built-in LRU cache (`collections.OrderedDict`) bounded to 50 items within the `ShortTermMemoryProvider`. When iterating over attachments, it now checks if `att.id` exists in the cache. If it does, the pre-processed LangChain parts are immediately injected. If it does not, it schedules a fetch task, caches the result upon completion, and prunes the cache to stay within its memory budget.

---
*PR created automatically by Jules for task [7310241605295902356](https://jules.google.com/task/7310241605295902356) started by @zi-yue-1129*