### PR TITLE
[Perf] Add LRU cache to ShortTermMemoryProvider attachment processing

### DIFF
--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -1,5 +1,6 @@
 from typing import List, Any
 import re
+from collections import OrderedDict
 
 import discord
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
@@ -14,17 +15,20 @@ class ShortTermMemoryProvider:
     each Discord message to a LangChain HumanMessage or AIMessage.
     """
 
-    def __init__(self, bot: Any, limit: int = 10):
+    def __init__(self, bot: Any, limit: int = 10, max_cache_size: int = 100):
         """
         Initialize the provider.
 
         Args:
             limit: maximum number of recent messages to fetch from channel.
+            max_cache_size: maximum number of processed attachments to keep in cache.
         """
         if not isinstance(limit, int) or limit <= 0:
             raise ValueError("limit must be a positive integer")
         self.limit = limit
         self.bot = bot
+        self.max_cache_size = max_cache_size
+        self._attachment_cache = OrderedDict()
 
     async def get(self, message: discord.Message) -> List[BaseMessage]:
         """
@@ -44,20 +48,30 @@ class ShortTermMemoryProvider:
 
             # Pre-fetch all attachments concurrently
             attachment_tasks = []
-            task_mapping = []  # To map task index back to msg.id
+            task_mapping = []  # To map task index back to (msg.id, att.id)
+            attachment_results_by_msg = {}
+
             if _att_cfg.enabled:
                 for msg in history:
                     if msg.attachments:
                         for att in msg.attachments:
-                            attachment_tasks.append(process_attachment(att))
-                            task_mapping.append(msg.id)
+                            if att.id in self._attachment_cache:
+                                # Cache hit: update LRU order and use cached result
+                                cached_res = self._attachment_cache.pop(att.id)
+                                self._attachment_cache[att.id] = cached_res
+                                attachment_results_by_msg.setdefault(msg.id, []).extend(cached_res)
+                            else:
+                                attachment_tasks.append(process_attachment(att))
+                                task_mapping.append((msg.id, att.id))
 
-            attachment_results_by_msg = {}
             if attachment_tasks:
                 import asyncio
                 results = await asyncio.gather(*attachment_tasks, return_exceptions=True)
-                for msg_id, res in zip(task_mapping, results):
+                for (msg_id, att_id), res in zip(task_mapping, results):
                     if not isinstance(res, Exception) and isinstance(res, list):
+                        self._attachment_cache[att_id] = res
+                        if len(self._attachment_cache) > self.max_cache_size:
+                            self._attachment_cache.popitem(last=False)
                         attachment_results_by_msg.setdefault(msg_id, []).extend(res)
                     else:
                         # Fallback or log error could go here if process_attachment didn't handle it


### PR DESCRIPTION
**What was found:** `ShortTermMemoryProvider.get()` retrieves the recent message history (last N messages) from the channel for every incoming message. For messages with attachments (images, PDFs, videos), it downloads, decodes, and resizes them unconditionally. Because the sliding window overlaps heavily between consecutive messages, the exact same attachments are downloaded and processed redundantly.
**Where it is:** `llm/memory/short_term.py`, around lines 45-66.
**Why it matters:** Attachment processing involves heavy network I/O and CPU-bound operations (e.g., PIL image resizing, PDF rendering). Repeatedly performing these operations for unchanged historical messages significantly increases the bot's response latency and wastes server resources.
**What was done:** Introduced an LRU cache (`_attachment_cache` using `collections.OrderedDict`) in `ShortTermMemoryProvider.__init__`. Updated the `get` method to check this cache using `attachment.id` before dispatching to `process_attachment`. Cache hits reuse the processed LangChain content parts, updating their LRU position, while misses process the attachment and store it up to `max_cache_size`.

---
*PR created automatically by Jules for task [685801361623103661](https://jules.google.com/task/685801361623103661) started by @zi-yue-1129*