### PR TITLE
[Security] Prevent RCE in MathCalculatorCog

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -174,6 +174,25 @@ class MathCalculatorCog(commands.Cog):
             # Use extracted expression
             expression = extracted
 
+
+            # Validate expression for suspicious patterns
+            dangerous_patterns = [
+                r'__',
+                r'globals',
+                r'locals',
+                r'exec',
+                r'import',
+                r'open',
+                r'eval',
+                r'compile'
+            ]
+            for pattern in dangerous_patterns:
+                if re.search(pattern, expression, re.IGNORECASE):
+                    error_message = self.lang_manager.translate(
+                        guild_id, "commands", "math", "responses", "error_unsupported_elements"
+                    ) if self.lang_manager else "Error: Expression contains unsafe patterns."
+                    return error_message
+
             # Safely parse expression
             sympy_expr = parse_expr(
                 expression,


### PR DESCRIPTION
1. **What was found**: A Remote Code Execution (RCE) vulnerability exists in the bot's math command. Untrusted mathematical expressions provided by the user are evaluated via SymPy's `parse_expr(..., evaluate=True)`. Although Python builtins were disabled using `global_dict={'__builtins__': {}}`, an attacker can still execute arbitrary code by utilizing double underscores (`__`) to access Python's object hierarchy and instantiate built-in modules (e.g. `().__class__.__base__.__subclasses__()[idx]()._module.__builtins__['__import__']('os').system('...')`).
2. **Where it is**: `cogs/math.py`, specifically inside the `calculate_math` function where `parse_expr` is called.
3. **Why it matters**: A malicious Discord user can exploit this to execute shell commands directly on the host machine running the PigPig bot. This compromises the entire system, exposing API keys, databases, and allowing full bot takeover.
4. **What was done**: Added a pre-validation block to explicitly reject expressions that contain dangerous keywords (such as `import`, `eval`, `exec`) or double underscores (`__`). This strictly mitigates the known object traversal escape vectors without breaking legitimate mathematical syntax. If an unsafe pattern is detected, the command securely returns a translated warning message.

---
*PR created automatically by Jules for task [18201059565878611592](https://jules.google.com/task/18201059565878611592) started by @zi-yue-1129*