### PR TITLE
[Perf] Add LRU cache to ShortTermMemoryProvider for attachment processing

### DIFF
--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -1,5 +1,6 @@
 from typing import List, Any
 import re
+from collections import OrderedDict
 
 import discord
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
@@ -14,17 +15,20 @@ class ShortTermMemoryProvider:
     each Discord message to a LangChain HumanMessage or AIMessage.
     """
 
-    def __init__(self, bot: Any, limit: int = 10):
+    def __init__(self, bot: Any, limit: int = 10, max_cache_size: int = 50):
         """
         Initialize the provider.
 
         Args:
             limit: maximum number of recent messages to fetch from channel.
+            max_cache_size: maximum number of processed attachments to keep in memory.
         """
         if not isinstance(limit, int) or limit <= 0:
             raise ValueError("limit must be a positive integer")
         self.limit = limit
         self.bot = bot
+        self._attachment_cache: OrderedDict = OrderedDict()
+        self._max_cache_size = max_cache_size
 
     async def get(self, message: discord.Message) -> List[BaseMessage]:
         """
@@ -44,21 +48,32 @@ class ShortTermMemoryProvider:
 
             # Pre-fetch all attachments concurrently
             attachment_tasks = []
-            task_mapping = []  # To map task index back to msg.id
+            task_mapping = []  # To map task index back to (msg.id, att.id)
+            attachment_results_by_msg = {}
+
             if _att_cfg.enabled:
                 for msg in history:
                     if msg.attachments:
                         for att in msg.attachments:
-                            attachment_tasks.append(process_attachment(att))
-                            task_mapping.append(msg.id)
+                            if att.id in self._attachment_cache:
+                                # Cache hit: move to end to mark as recently used
+                                res = self._attachment_cache.pop(att.id)
+                                self._attachment_cache[att.id] = res
+                                attachment_results_by_msg.setdefault(msg.id, []).extend(res)
+                            else:
+                                attachment_tasks.append(process_attachment(att))
+                                task_mapping.append((msg.id, att.id))
 
-            attachment_results_by_msg = {}
             if attachment_tasks:
                 import asyncio
                 results = await asyncio.gather(*attachment_tasks, return_exceptions=True)
-                for msg_id, res in zip(task_mapping, results):
+                for (msg_id, att_id), res in zip(task_mapping, results):
                     if not isinstance(res, Exception) and isinstance(res, list):
                         attachment_results_by_msg.setdefault(msg_id, []).extend(res)
+                        # Add to LRU cache
+                        self._attachment_cache[att_id] = res
+                        if len(self._attachment_cache) > self._max_cache_size:
+                            self._attachment_cache.popitem(last=False)
                     else:
                         # Fallback or log error could go here if process_attachment didn't handle it
                         pass


### PR DESCRIPTION
**1. What was found**
The `ShortTermMemoryProvider.get()` method fetches recent channel messages and processes their attachments. Because this provider operates on a sliding window of recent messages, the same attachment on an older message could be processed (downloaded, resized, and encoded) multiple times across consecutive Bot invocations, causing redundant I/O and slowing down the response time.

**2. Where it is**
File: `llm/memory/short_term.py`
Method: `ShortTermMemoryProvider.get`

**3. Why it matters**
Attachment processing (especially for images, PDFs, or videos) is resource and network intensive. Caching these results reduces unnecessary latency and CPU load when processing the same recent message multiple times.

**4. What was done**
- Introduced a bounded LRU cache (`OrderedDict`) in `ShortTermMemoryProvider` initialized with a default `max_cache_size` of 50.
- Updated the attachment processing loop in `get()` to first check if an `attachment.id` exists in `self._attachment_cache`.
- On a cache hit, the result is re-inserted to move it to the end (marking it as recently used) and directly appended to the context.
- On a cache miss, the attachment is processed concurrently via `asyncio.gather` as before, and the result is subsequently saved in the cache. Oldest items are evicted via `popitem(last=False)` if the cache size exceeds the limit.

---
*PR created automatically by Jules for task [5861827094481498271](https://jules.google.com/task/5861827094481498271) started by @zi-yue-1129*